### PR TITLE
Fix |ngx_token_binding_key_type| for RSA keys.

### DIFF
--- a/src/ngx_token_binding_module.c
+++ b/src/ngx_token_binding_module.c
@@ -182,11 +182,11 @@ ngx_token_binding_key_type(ngx_str_t *id, ngx_str_t *out)
     switch (tbGetKeyType(id->data, id->len)) {
 
     case TB_RSA2048_PKCS15:
-        ngx_str_set(out, "rsa2048-pss");
+        ngx_str_set(out, "rsa2048-pkcs1.5");
         break;
 
     case TB_RSA2048_PSS:
-        ngx_str_set(out, "rsa2048-pkcs1.5");
+        ngx_str_set(out, "rsa2048-pss");
         break;
 
     case TB_ECDSAP256:


### PR DESCRIPTION
|ngx_token_binding_key_type| is presently broken for RSA keys. It sets out to rsa2048-pss for |TB_RSA2048_PKCS15| not |TB_RSA2048_PSS|, and it sets out to rsa2048-pkcs1.5 for |TB_RSA2048_PSS| not |TB_RSA2048_PKCS15|. Somewhere along the line these two were mixed up.

This change switches them around and does nothing more.